### PR TITLE
shinier fps counter etc

### DIFF
--- a/www/roundManager.js
+++ b/www/roundManager.js
@@ -19,11 +19,15 @@ var scoreText = game.add.text(game.camera.x + 16, game.camera.y + 16, '', { font
 
 var roundRunning = false;
 
-var qr = game.add.sprite(game.camera.x + game.camera.width, game.camera.y + game.camera.height, 'qr_niko'); //or: 'qr_janika'
+var qr = game.add.image(game.camera.x + game.camera.width, game.camera.y + game.camera.height, 'qr_niko'); //or: 'qr_janika'
 qr.scale.x = 0.5*scalingFactors.x;
 qr.scale.y = 0.5*scalingFactors.y;
 qr.anchor.setTo(1,1);
 
+var fpsText = game.add.text(game.camera.x, game.camera.y + game.camera.height, '', { fontSize: '12px', fill: '#f00'});
+fpsText.anchor.setTo(0, 1);
+fpsText.stroke = '#000000';
+fpsText.strokeThickness = 1;
 
 // Variables related to map functioning
 
@@ -165,6 +169,11 @@ self.update = function ()
 
 	qr.bringToTop();
 	qr.position.setTo(game.camera.x + game.camera.width, game.camera.y + game.camera.height);
+
+	fpsText.bringToTop();
+	fpsText.text = ' FPS: ' + game.time.fps + '\n now.elapsed: ' + game.time.elapsed + 'ms\n time.elapsed: ' + game.time.elapsedMS + 'ms';
+	fpsText.position.setTo(game.camera.x, game.camera.y + game.camera.height);
+
 
 	if (roundRunning && lastPaused < game.time.now && !self.roundOver)
 		{


### PR DESCRIPTION
- qr code in roundmanager switched from sprite to image
- new text based fps counter
- elapsed ms counters based on phasers 'now' and 'time' (= js Date.now() ) 
