### PR TITLE
Player emitter fix

### DIFF
--- a/www/player.js
+++ b/www/player.js
@@ -390,6 +390,8 @@ self.kill = function ()
 				emitterList[i].on = false;
 				}
 		}
+
+	activePowerUps = [];
 	};
 
 


### PR DESCRIPTION
Still has the problem of pre-death emitted particles persisting for a while in respawn.
