### PR TITLE
Nonlinear bullets

### DIFF
--- a/www/enemy.js
+++ b/www/enemy.js
@@ -308,9 +308,9 @@ var attack = function ()
 					{
 					if(i === currentPattern.bulletAmount)
 						{
-							bulletManager.createBullet(currentPattern.bulletGraphic, currentPattern.bulletDamage, -1, angle, self.sprite.position, bulletSpeed, currentPattern.bulletLifespan, 'sine');
+							bulletManager.createBullet(currentPattern.bulletGraphic, currentPattern.bulletDamage, -1, angle, self.sprite.position, bulletSpeed, currentPattern.bulletLifespan);
 						} else {
-							bulletManager.createBullet(currentPattern.lineBulletGraphic, currentPattern.lineBulletDamage, -1, angle, self.sprite.position, bulletSpeed, currentPattern.bulletLifespan, 'sine');
+							bulletManager.createBullet(currentPattern.lineBulletGraphic, currentPattern.lineBulletDamage, -1, angle, self.sprite.position, bulletSpeed, currentPattern.bulletLifespan);
 						}
 					bulletSpeed = bulletSpeed + currentPattern.bulletSpeedVariance;
 					}

--- a/www/enemyManager.js
+++ b/www/enemyManager.js
@@ -63,7 +63,7 @@ var MaxEnemiesToSpawn = 0; 		//The maximum amount of enemies we try to spawn on 
 
 var enemiesToSpawn = 1; 		//The actual number of enemies we attempt to spawn
 
-var SPAWNING =false;
+var SPAWNING = true;
 
 var spawningDistance = 50; 		// The minimum distance of spawned creature to closest player. BEWARE! if too big the game performance will suffer while trying to spawn creatures.
 

--- a/www/player.js
+++ b/www/player.js
@@ -45,7 +45,6 @@ var flipped = false;
 
 var baseFireRate;
 var fireRate;
-var special;
 
 var nextFire = 0;
 
@@ -164,7 +163,6 @@ self.update = function ()
 				bulletDamage = info.bulletDamage;
 				bulletSpeed = info.bulletSpeed;
 				bulletLifespan = info.bulletLifespan;
-        special = info.special;
 				self.maxHealth = info.maxHealth;
 				self.currentHealth = self.maxHealth;
 
@@ -201,7 +199,7 @@ self.update = function ()
 			if (shooting && (game.time.now > nextFire))
 				{
 				nextFire = game.time.now + fireRate;
-				bulletManager.createBullet(bullets[self.playerClass], bulletDamage, self.id, input.shootAngle, self.sprite.position, bulletSpeed, bulletLifespan, special);
+				bulletManager.createBullet(bullets[self.playerClass], bulletDamage, self.id, input.shootAngle, self.sprite.position, bulletSpeed, bulletLifespan);
 				}
 			self.weapon.sprite.angle = input.shootAngle;
 			self.weapon.update(flipped, input);		

--- a/www/playerPatternList.js
+++ b/www/playerPatternList.js
@@ -28,24 +28,22 @@ playerPatterns["1"] =
 playerPatterns["2"] =
 	{
 	baseMovementSpeed: 200,
-	baseFireRate: 200,
+	baseFireRate: 500,
 	bulletDamage: 10,
-	bulletSpeed: 200,
-	bulletLifespan: 5000,
-	maxHealth: 120,
-  special: {type: 'sine', amplitude: 100, period: 4}
+	bulletSpeed: 2000,
+	bulletLifespan: 500,
+	maxHealth: 120
 	};
 
 //viking
 playerPatterns["3"] =
 	{
 	baseMovementSpeed: 180,
-	baseFireRate: 200,
+	baseFireRate: 350,
 	bulletDamage: 4,
-	bulletSpeed: 200,
-	bulletLifespan: 5000,
-	maxHealth: 250,
-  special: {type: 'sawTooth', amplitude: 100, period: 4}
+	bulletSpeed: 800,
+	bulletLifespan: 400,
+	maxHealth: 250
 	};
 
 //ninja

--- a/www/roundManager.js
+++ b/www/roundManager.js
@@ -59,7 +59,7 @@ var currentMinDY = defaultMinDY;
 
 var speedDict = [];
 speedDict["slow"] = 0.25;
-speedDict["normal"] =0;
+speedDict["normal"] = 0.5;
 speedDict["fast"] = 1;
 speedDict["stop"] = null;
 


### PR DESCRIPTION
Added capabilities for nonlinear bullet movement.

Usage: 
when creating a bullet by bulletmanager.createbullet, just add a new object characterizing the special attributes that you want your bullet to have at the end of the argument list.

Currently supported nonlinear movement patterns:
- Sine 
- Sawtooth

Please note that while in sawtooth amplitude and period are independent of each other (as it reasonably should), in sine such property does not hold (as it nonreasonably should).

Example usage:

...
bulletManager.createBullet(..........., {type: 'sine', ampiltude: '50', period: '2'});
...

creates a bullet with sine movement.
and

....
bulletManager.createBullet(..........,{type: 'sawTooth', amplitude: '50', period: '2'});
....

creates a b ullet with sawTooth movement.
